### PR TITLE
reduant rate-limit logic cleaned up

### DIFF
--- a/empowerai-backend/src/app.js
+++ b/empowerai-backend/src/app.js
@@ -38,7 +38,12 @@ if (isEnabled(process.env.ENABLE_AI_RATE_LIMITER, true)) {
 }
 
 if (isEnabled(process.env.ENABLE_API_RATE_LIMITER, true)) {
-  app.use('/api', apiLimiter);
+  app.use('/api/account', apiLimiter);
+  app.use('/api/opportunities', apiLimiter);
+  app.use('/api/admin', apiLimiter);
+  app.use('/api/user', apiLimiter);
+  app.use('/api/applications', apiLimiter);
+  app.use('/api/rss', apiLimiter);
 }
 
 // Request logging


### PR DESCRIPTION
## fix(middleware): remove redundant rate limiter double-application (#43)

### Summary
Replace the broad `app.use('/api', apiLimiter)` catch-all with explicit per-route mounting. Previously, routes already covered by `authLimiter` or `aiServiceLimiter` were also being hit by `apiLimiter` because Express matches all middleware whose path prefix matches the request URL.

---

### Problem

Express middleware path matching is prefix-based, not exact. This meant:

- `POST /api/auth/login` → hit `authLimiter` ✅ then `apiLimiter` ❌ (double-limited)
- `POST /api/cv/analyze` → hit `aiServiceLimiter` ✅ then `apiLimiter` ❌ (double-limited)
- `POST /api/twin/generate` → hit `aiServiceLimiter` ✅ then `apiLimiter` ❌ (double-limited)

This caused:
1. **Incorrect rate limit counts** — each request consumed quota from two separate limiters
2. **Misleading `RateLimit-*` response headers** — the last limiter to run overwrote headers from the first
3. **Unpredictable 429 behaviour** — a request could be rejected by `apiLimiter` (100 req/15min) long before `authLimiter` (5 req/15min) was exhausted, masking the actual limiting intent

---

### Change

**Before (`app.js`):**
```js
if (isEnabled(process.env.ENABLE_API_RATE_LIMITER, true)) {
  app.use('/api', apiLimiter); // ← hits ALL /api/* routes
}
```

**After (`app.js`):**
```js
if (isEnabled(process.env.ENABLE_API_RATE_LIMITER, true)) {
  app.use('/api/account', apiLimiter);
  app.use('/api/opportunities', apiLimiter);
  app.use('/api/admin', apiLimiter);
  app.use('/api/user', apiLimiter);
  app.use('/api/applications', apiLimiter);
  app.use('/api/rss', apiLimiter);
}
```

Routes not included (already have dedicated limiters):
| Route | Limiter |
|---|---|
| `/api/auth` | `authLimiter` |
| `/api/cv` | `aiServiceLimiter` |
| `/api/twin` | `aiServiceLimiter` |
| `/api/interview` | `aiServiceLimiter` |
| `/api/chat` | `aiServiceLimiter` |
| `/api/health` | intentionally unlimited |

---

### Files Changed
- `app.js` — rate limit block only

### Files Confirmed Unchanged
- `server.js` — no rate limit logic (correct)
- `middleware/rateLimiter.js` — limiter configs unchanged

---

### Notes
- No changes to limiter behaviour, window sizes, or max values
- `ENABLE_API_RATE_LIMITER` env flag still works as before
- Verify `express-rate-limit` is v7+ in `package.json` — `ipKeyGenerator` used in `aiServiceLimiter` was introduced in v7 and will silently break on v6