### PR TITLE
fix(subscription): apply protect and ownership check to routes

### DIFF
--- a/empowerai-backend/src/modules/subscription/subscription.route.js
+++ b/empowerai-backend/src/modules/subscription/subscription.route.js
@@ -15,6 +15,13 @@ const router = express.Router();
 const { body, param, query, validationResult } = require('express-validator');
 const { PLANS, BILLING_CYCLES } = require('../../config/plans.config');
 
+// `protect` is the existing JWT auth middleware (see
+// `src/middleware/auth.js`). It reads `Authorization: Bearer <token>`,
+// verifies the JWT, loads the user from Mongo, and sets `req.user`.
+// `restrictTo('admin')` is the existing role gate. It returns 403 if
+// `req.user.role` is not in the list of allowed roles.
+const { protect, restrictTo } = require('../../middleware/auth');
+
 const validPlanIds = Object.keys(PLANS).map((k) => k.toLowerCase());
 const validCycles = Object.values(BILLING_CYCLES);
 
@@ -28,19 +35,55 @@ const validate = (req, res, next) => {
   next();
 };
 
-// ─── AUTH MIDDLEWARE ──────────────────────────────────────────────────────────
-// Replace with your actual auth middleware from your existing auth module
+// ─── AUTH ────────────────────────────────────────────────────────────────────
+//
+// Background
+// ----------
+// The earlier `requireAuth` and `requireSuperAdmin` in this file called
+// `next()` with no checks. The TODO comments said "plug it in here" and
+// the real auth was not added. With those placeholders in place, every
+// endpoint below could be reached without a token. An anonymous caller
+// could change any user's plan, cancel any subscription, or list every
+// subscription record.
+//
+// The middlewares below replace those placeholders with real checks.
 
-const requireAuth = (req, res, next) => {
-  // Your existing auth middleware sets req.user — plug it in here
-  // e.g. require('../../middleware/auth')(req, res, next)
-  next();
+// Layer 1: caller has a valid login.
+//   - 401 if there is no `Authorization` header.
+//   - 401 if the JWT is invalid or expired.
+//   - On success, `req.user` is the User document loaded from Mongo.
+const requireAuth = protect;
+
+// Layer 2: caller is an admin.
+//   - 401 if `req.user` is missing (no `protect` earlier in the chain).
+//   - 403 if `req.user.role !== 'admin'`.
+//
+// The User model's role enum is `['user', 'admin']` (see
+// `src/modules/user/user.Model.js`). There is no `super_admin` role,
+// even though the earlier comment referenced one.
+const requireAdmin = restrictTo('admin');
+
+// Layer 3: for per-user routes (e.g. `/api/subscriptions/:userId/plan`),
+// the caller's `req.user._id` must match the target userId on the
+// request. Without this check, a logged-in user could cancel another
+// user's subscription by changing the `:userId` in the URL.
+//
+// `userIdFrom` is a function that pulls the target userId off the
+// request, from either `req.params.userId` or `req.body.userId`
+// depending on the route. Admins skip the match check and can act on
+// any userId.
+const requireOwnerOrAdmin = (userIdFrom) => (req, res, next) => {
+  const targetId = userIdFrom(req);
+  const callerId = req.user?._id?.toString();
+  if (req.user?.role === 'admin' || (callerId && callerId === String(targetId))) {
+    return next();
+  }
+  return res.status(403).json({ success: false, message: 'Forbidden' });
 };
 
-const requireSuperAdmin = (req, res, next) => {
-  // e.g. if (req.user.role !== 'super_admin') return res.status(403).json(...)
-  next();
-};
+// Two ready-made versions, one for each place the target userId can live.
+const ownerFromParams = requireOwnerOrAdmin((req) => req.params.userId); // for /:userId/... routes
+const ownerFromBody = requireOwnerOrAdmin((req) => req.body.userId);     // for POST /trial, POST /checkout
 
 // ─── ROUTES ───────────────────────────────────────────────────────────────────
 
@@ -48,10 +91,14 @@ const requireSuperAdmin = (req, res, next) => {
  * POST /api/subscriptions/trial
  * Start a trial subscription for a newly registered EmpowerAI user.
  * Call this from your registration controller after user is created.
+ *
+ * Auth: must be logged in AND the `userId` in the body must match the
+ *       caller's own userId (admins can pass any userId).
  */
 router.post(
   '/trial',
-  requireAuth,
+  requireAuth,    // 401 if not logged in
+  ownerFromBody,  // 403 if trying to start a trial for someone else's userId
   [
     body('userId').notEmpty().withMessage('userId is required'),
     body('planId')
@@ -74,10 +121,14 @@ router.post(
 /**
  * GET /api/subscriptions/user/:userId
  * Get the active subscription for a user.
+ *
+ * Auth: must be logged in AND `:userId` in the URL must match the
+ *       caller's own userId (admins can read anyone's).
  */
 router.get(
   '/user/:userId',
-  requireAuth,
+  requireAuth,      // 401 if not logged in
+  ownerFromParams,  // 403 if trying to read someone else's subscription
   [param('userId').notEmpty()],
   validate,
   async (req, res) => {
@@ -95,11 +146,17 @@ router.get(
 
 /**
  * GET /api/subscriptions
- * List all subscriptions. Super admin only.
+ * List all subscriptions. Admin only.
+ *
+ * Auth: must be logged in AND have `role === 'admin'`. Regular users get 403.
+ *
+ * (The route's old "super admin only" comment referred to a role that
+ * doesn't exist in `user.Model.js`. The real top role is `admin`.)
  */
 router.get(
   '/',
-  requireSuperAdmin,
+  requireAuth,    // 401 if not logged in
+  requireAdmin,   // 403 if logged in but not an admin
   [
     query('status').optional().isString(),
     query('planId').optional().isIn(validPlanIds),
@@ -122,10 +179,15 @@ router.get(
  * POST /api/subscriptions/checkout
  * Initialise a Paystack transaction for a user subscribing to or upgrading a plan.
  * Returns { authorizationUrl } — redirect the user's browser to this URL.
+ *
+ * Auth: must be logged in AND the `userId` in the body must match the
+ *       caller's own userId. Otherwise an attacker could pay-as-someone-else
+ *       or set up a checkout under another user's email/billing record.
  */
 router.post(
   '/checkout',
-  requireAuth,
+  requireAuth,    // 401 if not logged in
+  ownerFromBody,  // 403 if userId in body isn't the caller's own
   [
     body('userId').notEmpty().withMessage('userId is required'),
     body('planId').isIn(validPlanIds).withMessage(`planId must be one of: ${validPlanIds.join(', ')}`),
@@ -160,10 +222,14 @@ router.post(
 /**
  * PATCH /api/subscriptions/:userId/plan
  * Upgrade or downgrade a user's plan.
+ *
+ * Auth: must be logged in AND `:userId` in the URL must match the caller's
+ *       own userId (admins can change anyone's plan).
  */
 router.patch(
   '/:userId/plan',
-  requireAuth,
+  requireAuth,      // 401 if not logged in
+  ownerFromParams,  // 403 if trying to change someone else's plan
   [
     param('userId').notEmpty(),
     body('planId').isIn(validPlanIds).withMessage(`planId must be one of: ${validPlanIds.join(', ')}`),
@@ -185,10 +251,15 @@ router.patch(
 /**
  * POST /api/subscriptions/:userId/cancel
  * Schedule a subscription cancellation at the end of the current billing period.
+ *
+ * Auth: must be logged in AND `:userId` in the URL must match the caller's
+ *       own userId (admins can cancel anyone's). Without this, a logged-in
+ *       user could cancel any other user's subscription by guessing their id.
  */
 router.post(
   '/:userId/cancel',
-  requireAuth,
+  requireAuth,      // 401 if not logged in
+  ownerFromParams,  // 403 if trying to cancel someone else's subscription
   [
     param('userId').notEmpty(),
     body('reason').optional().isString().isLength({ max: 500 }),
@@ -209,10 +280,14 @@ router.post(
 /**
  * POST /api/subscriptions/:userId/reactivate
  * Undo a scheduled cancellation before the billing period ends.
+ *
+ * Auth: must be logged in AND `:userId` in the URL must match the caller's
+ *       own userId (admins can reactivate anyone's).
  */
 router.post(
   '/:userId/reactivate',
-  requireAuth,
+  requireAuth,      // 401 if not logged in
+  ownerFromParams,  // 403 if trying to reactivate someone else's subscription
   [param('userId').notEmpty()],
   validate,
   async (req, res) => {


### PR DESCRIPTION
## What

The router previously used local `requireAuth` and `requireSuperAdmin` middlewares that called `next()` with no checks. The TODO comments indicated real auth was to be added later. Routes under `/api/subscriptions` could be reached without a token in the meantime.

This PR replaces those placeholders with the existing `protect` and `restrictTo('admin')` from `src/middleware/auth.js`, and adds an ownership check on per-user routes.

## Routes affected

| Route | Auth |
| --- | --- |
| `POST /trial` | logged in + caller owns body.userId (or admin) |
| `GET /user/:userId` | logged in + caller owns :userId (or admin) |
| `GET /` | logged in + admin role |
| `POST /checkout` | logged in + caller owns body.userId (or admin) |
| `PATCH /:userId/plan` | logged in + caller owns :userId (or admin) |
| `POST /:userId/cancel` | logged in + caller owns :userId (or admin) |
| `POST /:userId/reactivate` | logged in + caller owns :userId (or admin) |

## Test plan

Run `npm run dev` in `empowerai-backend/` and check the following:

- Anonymous `GET /api/subscriptions` returns 401.
- Logged-in user reading another user's record (`GET /api/subscriptions/user/<other-id>`) returns 403.
- Logged-in user reading their own record returns 200.
- Admin `GET /api/subscriptions` returns 200.
- Non-admin `GET /api/subscriptions` returns 403.

## Notes

- The user model role enum (`src/modules/user/user.Model.js`) is `['user', 'admin']`, so the admin gate uses `restrictTo('admin')`. The earlier `super_admin` reference in the comments was a placeholder name.
- The ownership helper compares `req.user._id` to the userId on the request. Admins skip the match.
- Inline comments in the file describe the cause and effect for each middleware layer.

## Risk

Endpoints that were anonymously reachable now return 401 without a token, and 403 for a non-matching userId. Any internal script that previously called these endpoints without a token will need a service-account token.