### PR TITLE
fix(ai-service): require X-Service-Token on CV endpoints

### DIFF
--- a/ai-service/app/__init__.py
+++ b/ai-service/app/__init__.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 
@@ -7,6 +7,11 @@ import uuid
 
 from app.utils.logger import get_logger
 from app.config.config import settings
+
+# Shared-secret check applied to every CV endpoint below.
+# Without this check, anyone can call the public Render URL and consume
+# the upstream API quota. Defined in `app/middleware/auth.py`.
+from app.middleware.auth import verify_service_token
 
 logger = get_logger()
 
@@ -74,15 +79,25 @@ def create_app() -> FastAPI:
         router as cv_revamp_router,
     )
 
+    # `dependencies=[Depends(verify_service_token)]` runs the token check
+    # before every route in the router. Each route under `/api/cv/...`
+    # and `/api/cv/revamp/...` then needs a valid `X-Service-Token`
+    # header. If the header is missing or wrong, the request returns
+    # 401, the model is not called, and no upstream API quota is used.
+    #
+    # A router mounted without this `dependencies=` value would be
+    # publicly callable.
     app.include_router(
         cv_analyzer_router,
         prefix="/api/cv",
         tags=["CV Analyzer"],
+        dependencies=[Depends(verify_service_token)],
     )
     app.include_router(
         cv_revamp_router,
         prefix="/api/cv/revamp",
         tags=["CV Revamp"],
+        dependencies=[Depends(verify_service_token)],
     )
 
     logger.info("App initialized successfully")

--- a/ai-service/app/middleware/auth.py
+++ b/ai-service/app/middleware/auth.py
@@ -1,3 +1,11 @@
+# `hmac.compare_digest` is used below for a constant-time string check.
+# Python's `==` and `!=` on strings stop at the first byte that differs.
+# The time to fail then depends on how many leading bytes were correct.
+# Over many timed requests, that timing can reveal the secret one byte
+# at a time. `compare_digest` always reads both inputs fully and so
+# does not have this timing signal.
+import hmac
+
 from fastapi import Request, HTTPException, Depends
 from app.config.config import settings
 
@@ -5,7 +13,12 @@ from app.config.config import settings
 async def verify_service_token(request: Request):
     token = request.headers.get("X-Service-Token")
 
-    if not token or token != settings.SERVICE_SECRET:
+    # Two cases return 401:
+    #   1. `not token` -> no header on the request.
+    #   2. `not compare_digest(...)` -> header is present but does not match.
+    # `compare_digest` is the constant-time check described at the top
+    # of this file.
+    if not token or not hmac.compare_digest(token, settings.SERVICE_SECRET):
         raise HTTPException(status_code=401, detail="Unauthorized")
 
     return True


### PR DESCRIPTION
## What

`verify_service_token` is defined in `app/middleware/auth.py` but was not attached to any router. The endpoints under `/api/cv/` and `/api/cv/revamp/` could be reached without the `X-Service-Token` header.

This PR:

- Adds `dependencies=[Depends(verify_service_token)]` to both `include_router(...)` calls in `app/__init__.py`. Each CV route now needs a valid `X-Service-Token` header.
- Switches the token comparison from `!=` to `hmac.compare_digest`. The new comparison is constant-time, so it does not leak timing about the secret one byte at a time.

## Test plan

Run `python -m uvicorn main:app --reload` in `ai-service/` and check:

- `POST /api/cv/text` with no header returns 401.
- `POST /api/cv/text` with `X-Service-Token: wrong` returns 401.
- `POST /api/cv/text` with the correct `X-Service-Token` returns 200.
- Same for `POST /api/cv/upload` and `POST /api/cv/revamp/`.

## Caller-side note

The Express backend already sends `X-Service-Token` on its outgoing calls to the AI service. For the calls to succeed after this deploys, the matching secret value needs to be present in both services' env (`AI_SERVICE_API_KEY` on the backend, `SERVICE_SECRET` on the AI service, or whatever names you settle on, as long as they match).

A quick check from the backend side: `grep -rn "X-Service-Token\|AI_SERVICE_API_KEY" empowerai-backend/src/`.

## Risk

After this deploys, any client that does not send `X-Service-Token` receives 401. This includes any direct call to the AI service that does not go through the Express backend.