### PR TITLE
fix(cors): hostname-match vercel.app, remove NODE_ENV bypass

### DIFF
--- a/empowerai-backend/src/infrastructures/cors.js
+++ b/empowerai-backend/src/infrastructures/cors.js
@@ -12,14 +12,49 @@ const allowedOrigins = [
   process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null,
 ].filter(Boolean);
 
+// Allows Vercel preview deploys (auto-generated `*.vercel.app` URLs per
+// PR or branch) without listing each one.
+//
+// This uses `hostname.endsWith('.vercel.app')` rather than
+// `origin.includes('vercel.app')`. `includes` is a substring match and
+// also accepts URLs like:
+//
+//   https://vercel.app.attacker.com    (hostname: vercel.app.attacker.com)
+//   https://evil-vercel.app.com        (hostname: evil-vercel.app.com)
+//
+// The hostname-suffix form, with the leading dot, only matches a real
+// subdomain of `vercel.app`. `vercel.app.attacker.com` ends in `.com`,
+// so it does not match.
+function isVercelPreview(origin) {
+  try {
+    return new URL(origin).hostname.endsWith('.vercel.app');
+  } catch {
+    // `new URL()` throws on a malformed origin. That counts as not allowed.
+    return false;
+  }
+}
+
+// Opt-in dev flag for local testing (e.g. through ngrok or a tunnel).
+//
+// This replaces the earlier `process.env.NODE_ENV !== 'production'`
+// clause, which opened the allow-list to every origin whenever
+// `NODE_ENV` was anything other than the exact string `'production'`
+// (unset, typo, `development`, etc.).
+//
+// `ALLOW_ANY_ORIGIN_DEV` defaults to `false`, so a missing env var
+// keeps the allow-list closed.
+const allowAnyOriginDev = process.env.ALLOW_ANY_ORIGIN_DEV === 'true';
+
 const corsOptions = {
   origin: function (origin, callback) {
     if (!origin) return callback(null, true);
 
     const isAllowed =
+      // Dev flag, only true when `ALLOW_ANY_ORIGIN_DEV=true`.
+      allowAnyOriginDev ||
       allowedOrigins.indexOf(origin) !== -1 ||
-      origin?.includes('vercel.app') ||
-      process.env.NODE_ENV !== 'production';
+      // Hostname-suffix match for Vercel preview URLs (see `isVercelPreview`).
+      isVercelPreview(origin);
 
     if (isAllowed) {
       callback(null, true);


### PR DESCRIPTION
## What

`empowerai-backend/src/infrastructures/cors.js` previously used two checks that accept unintended origins:

1. `origin?.includes('vercel.app')` is a substring match. URLs like `vercel.app.attacker.com` and `evil-vercel.app.com` contain the text `vercel.app` and so pass.
2. `process.env.NODE_ENV !== 'production'` allows every origin when `NODE_ENV` is unset, mistyped, or `development`.

Combined with `credentials: true` (line 30), either case lets a non-listed origin send credentialed cross-origin requests from a logged-in user's browser.

This PR:

- Adds `isVercelPreview()` that parses the origin URL and matches the hostname suffix `.vercel.app`. Real `*.vercel.app` previews still pass; lookalike hostnames do not.
- Removes the substring match and the `NODE_ENV` clause.
- Adds an opt-in `ALLOW_ANY_ORIGIN_DEV=true` flag for local development, which defaults to `false`.

## Test plan

`NODE_ENV=production npm run start` in `empowerai-backend/`, then send CORS preflights:

- `Origin: https://vercel.app.attacker.com` is rejected.
- `Origin: https://empower-ai-gamma-git-feature-x.vercel.app` is allowed.
- `Origin: https://www.empowa.org` is allowed.
- With `NODE_ENV` unset, `Origin: https://random.example` is rejected (was allowed before).

## Risk

The explicit `allowedOrigins` list is unchanged, so all current production and local-dev origins continue to work. Real Vercel preview deploys keep working via the hostname-suffix check. If any contributor's local dev was relying on the substring or `NODE_ENV` leniency, they can set `ALLOW_ANY_ORIGIN_DEV=true` in their `.env` (and a matching one-liner could be added to `.env.example` in a follow-up).